### PR TITLE
Throw exception if no webhook url

### DIFF
--- a/src/MicrosoftTeams.php
+++ b/src/MicrosoftTeams.php
@@ -31,9 +31,9 @@ class MicrosoftTeams
      * @param string $url
      * @param array $data
      *
-     *  @throws CouldNotSendNotification
+     * @throws CouldNotSendNotification
      *
-     *  @return ResponseInterface|null
+     * @return ResponseInterface|null
      */
     public function send(string $url, array $data): ?ResponseInterface
     {

--- a/src/MicrosoftTeamsChannel.php
+++ b/src/MicrosoftTeamsChannel.php
@@ -3,7 +3,6 @@
 namespace NotificationChannels\MicrosoftTeams;
 
 use Illuminate\Notifications\Notification;
-use NotificationChannels\MicrosoftTeams\Exceptions\CouldNotSendNotification;
 
 class MicrosoftTeamsChannel
 {

--- a/src/MicrosoftTeamsChannel.php
+++ b/src/MicrosoftTeamsChannel.php
@@ -28,17 +28,15 @@ class MicrosoftTeamsChannel
      * @param mixed $notifiable
      * @param Notification $notification
      *
-     * @throws CouldNotSendNotification
+     * @return ResponseInterface|null
      */
     public function send($notifiable, Notification $notification)
     {
         $message = $notification->toMicrosoftTeams($notifiable);
 
-        // if the recipient is not defined check if from the notifiable object
+        // if the recipient is not defined get it from the notifiable object
         if ($message->toNotGiven()) {
-            if (! $to = $notifiable->routeNotificationFor('microsoftTeams')) {
-                throw CouldNotSendNotification::microsoftTeamsWebhookUrlMissing();
-            }
+            $to = $notifiable->routeNotificationFor('microsoftTeams');
 
             $message->to($to);
         }

--- a/src/MicrosoftTeamsMessage.php
+++ b/src/MicrosoftTeamsMessage.php
@@ -42,7 +42,7 @@ class MicrosoftTeamsMessage
      * @param string $title - title
      * @param array $params - optional section can be defined (e.g. [$section = '1'].
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function title(string $title, array $params = []): self
     {
@@ -63,7 +63,7 @@ class MicrosoftTeamsMessage
      *
      * @param string $summary - summary
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function summary(string $summary): self
     {
@@ -77,7 +77,7 @@ class MicrosoftTeamsMessage
      *
      * @param string $type - type of the card
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function type(string $type): self
     {
@@ -92,7 +92,7 @@ class MicrosoftTeamsMessage
      * @param string $content
      * @param array $params - optional section can be defined (e.g. [$section = '1'].
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function content(string $content, array $params = []): self
     {
@@ -120,7 +120,7 @@ class MicrosoftTeamsMessage
      * * @param array $params - optional params (neexed for more complex types other than 'OpenUri' and for section)
      * For more information check out: https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function button(string $text, string $url = '', $type = 'OpenUri', array $params = []): self
     {
@@ -164,7 +164,7 @@ class MicrosoftTeamsMessage
      *
      * @param string|int $sectionId - in which section to put the property, defaults to standard_section
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function addStartGroupToSection($sectionId = 'standard_section'): self
     {
@@ -182,7 +182,7 @@ class MicrosoftTeamsMessage
      * @param string $activityText
      * @param string|int $sectionId - in which section to put the property, defaults to standard_section
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function activity(string $activityImage = '', string $activityTitle = '', string $activitySubtitle = '', string $activityText = '', $sectionId = 'standard_section'): self
     {
@@ -201,7 +201,7 @@ class MicrosoftTeamsMessage
      * @param string $value
      * @param string|int $sectionId - in which section to put the property, defaults to standard_section
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function fact(string $name, string $value, $sectionId = 'standard_section'): self
     {
@@ -218,7 +218,7 @@ class MicrosoftTeamsMessage
      * @param string $title - A short description of the image. Typically, title is displayed in a tooltip as the user hovers their mouse over the image
      * @param string|int $sectionId - in which section to put the property, defaults to standard_section
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function image(string $imageUri, string $title = '', $sectionId = 'standard_section'): self
     {
@@ -238,7 +238,7 @@ class MicrosoftTeamsMessage
      * @param string $title - A short description of the image. Typically, title is displayed in a tooltip as the user hovers their mouse over the image
      * @param string|int $sectionId - in which section to put the property, defaults to standard_section
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function heroImage(string $imageUri, string $title = '', $sectionId = 'standard_section'): self
     {
@@ -257,7 +257,7 @@ class MicrosoftTeamsMessage
      * @param array $options
      * @param string|int $sectionId - optional in which section to put the property
      *
-     * @return $this
+     * @return MicrosoftTeamsMessage $this
      */
     public function options(array $options, $sectionId = null): self
     {

--- a/src/MicrosoftTeamsMessage.php
+++ b/src/MicrosoftTeamsMessage.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\MicrosoftTeams;
 
+use NotificationChannels\MicrosoftTeams\Exceptions\CouldNotSendNotification;
+
 class MicrosoftTeamsMessage
 {
     /** @var array Params payload. */
@@ -272,10 +274,15 @@ class MicrosoftTeamsMessage
      *
      * @param $webhookUrl - url of webhook
      *
-     * @return $this
+     * @throws CouldNotSendNotification
+     *
+     * @return MicrosoftTeamsMessage $this
      */
-    public function to(string $webhookUrl): self
+    public function to(?string $webhookUrl): self
     {
+        if (! $webhookUrl) {
+            throw CouldNotSendNotification::microsoftTeamsWebhookUrlMissing();
+        }
         $this->webhookUrl = $webhookUrl;
 
         return $this;

--- a/tests/MicrosoftTeamsMessageTest.php
+++ b/tests/MicrosoftTeamsMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\MicrosoftTeams\Test;
 
+use NotificationChannels\MicrosoftTeams\Exceptions\CouldNotSendNotification;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 use PHPUnit\Framework\TestCase;
 
@@ -103,6 +104,16 @@ class MicrosoftTeamsMessageTest extends TestCase
         $message = new MicrosoftTeamsMessage();
         $message->to('https://outlook.office.com/webhook/abc-01234/IncomingWebhook/def-567');
         $this->assertEquals('https://outlook.office.com/webhook/abc-01234/IncomingWebhook/def-567', $message->getWebhookUrl());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_the_recipients_webhook_url_is_an_empty_string(): void
+    {
+        $message = new MicrosoftTeamsMessage();
+
+        $this->expectException(CouldNotSendNotification::class);
+
+        $message->to('');
     }
 
     /** @test */


### PR DESCRIPTION
If there is no webhook url defined there was no exception thrown but only an info that the to() method needs a string as param.
Refactored code to throw exception to be able to catch it in client code.