### PR TITLE
Refactor button to action, and add button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `teams` will be documented in this file
 
+## 2.0.0 - 2020-04-27
+
+### Breaking Change
+*Method button(string $text, string $url = '', array $params = []): has now only 3 params instead of 4 since the type param got obsolete. Please adapt your code if you were using more than the first required 2 params.*
+- change method button() to action() since this fits better to the documentation as [potential action](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions)
+- add button() method as a wrapper for straight forward use
+
 ## 1.0.0 - 2020-04-14
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ public function routeNotificationForMicrosoftTeams(Notification $notification)
 - `summary(string $summary)`: Summary of the message.
 - `type(string $type)`: Type which is used as theme color (any valid hex code or one of: primary|secondary|accent|error|info|success|warning).
 - `content(string $content)`: Content of the message (Markdown supported).
-- `button(string $text, string $url = '', $type = 'OpenUri', array $params = [])`: Text and url of a button. For more Infos about different types check out [this link](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions).
-- `options(array $options, $sectionId = null)`: Add additional options to pass to message payload object.
+- `button(string $text, string $url = '', array $params = [])`: Text and url of a button. Wrapper for an potential action.
+- `action(string $text, $type = 'OpenUri', array $params = [])`: Text and type for a potential action. Further params can be added depending on the action. For more infos about different types check out [this link](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions).
+- `options(array $options, $sectionId = null)`: Add additional options to pass to the message payload object.
 
 #### Sections
 It is possible to define one or many sections inside a message card. The following methods can be used within a section
@@ -128,10 +129,11 @@ It is possible to define one or many sections inside a message card. The followi
 - `image(string $imageUri, string $title = '', $sectionId = 'standard_section')`: Add an image to a section.
 - `heroImage(string $imageUri, string $title = '', $sectionId = 'standard_section')`: Add a hero image to a section.
 
-Additionally the title, content and button can be also added to a section through the optional `params` value:
+Additionally the title, content, button and action can be also added to a section through the optional `params` value:
 - `title(string $title, array $params = ['section' => 'my-section'])`: Title of the message and add it to `my-section`.
 - `content(string $content, array $params = ['section' => 'my-section'])`: Content of the message and add it to `my-section` (Markdown supported).
-- `button(string $text, string $url = '', $type = 'OpenUri', array $params = ['section' => 'my-section'])`: Text and url of a button and add it to `my-section`.
+- `button(string $text, string $url = '', array $params = ['section' => 'my-section'])`: Text and url of a button and add it to `my-section`.
+- `action(string $text, $type = 'OpenUri', array $params = ['section' => 'my-section'])`: Text and type of an potential action and add it to `my-section`.
 
 ## Changelog
 

--- a/src/MicrosoftTeamsMessage.php
+++ b/src/MicrosoftTeamsMessage.php
@@ -169,7 +169,7 @@ class MicrosoftTeamsMessage
                     'os'=> 'default',
                     'uri' => $url,
                 ],
-            ]
+            ],
         ];
 
         // fill additional params (if any)

--- a/src/MicrosoftTeamsMessage.php
+++ b/src/MicrosoftTeamsMessage.php
@@ -108,53 +108,76 @@ class MicrosoftTeamsMessage
     }
 
     /**
-     * Add a button.
+     * Add an action.
      *
-     * @param string $text - label of the button
-     * @param string $url - url to forward to
+     * @param string $name - name of the action
      * @param string $type - defaults to 'OpenUri' should be one of the following types:
      *  - OpenUri: Opens a URI in a separate browser or app; optionally targets different URIs based on operating systems
      *  - HttpPOST: Sends a POST request to a URL
      *  - ActionCard: Presents one or more input types and associated actions
      *  - InvokeAddInCommand: Opens an Outlook add-in task pane.
-     * * @param array $params - optional params (neexed for more complex types other than 'OpenUri' and for section)
+     * * @param array $params - optional params (needed for complex types and for section)
      * For more information check out: https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference
      *
      * @return MicrosoftTeamsMessage $this
      */
-    public function button(string $text, string $url = '', $type = 'OpenUri', array $params = []): self
+    public function action(string $name, $type = 'OpenUri', array $params = []): self
     {
 
         // fill required values for all types
-        $newButton = [
+        $newAction = [
             '@type' => $type,
-            'name' => $text,
+            'name' => $name,
         ];
-
-        // fill targets array for type 'OpenUri'
-        if ($type === 'OpenUri') {
-            $newButton['targets'] = [
-                (object) [
-                    'os'=> 'default',
-                    'uri' => $url,
-                ],
-            ];
-        }
 
         // fill additional params (needed for other types than 'OpenUri')
         if (! empty($params)) {
-            $newButton = array_merge($newButton, $params);
+            $newAction = array_merge($newAction, $params);
         }
 
         // if section is defined add it to specified section
         if (isset($params['section'])) {
-            // remove unsued property from newButton array
-            unset($newButton['section']);
+            // remove unsued property from newAction array
+            unset($newAction['section']);
             $sectionId = $params['section'];
-            $this->payload['sections'][$sectionId]['potentialAction'][] = (object) $newButton;
+            $this->payload['sections'][$sectionId]['potentialAction'][] = (object) $newAction;
         } else {
-            $this->payload['potentialAction'][] = (object) $newButton;
+            $this->payload['potentialAction'][] = (object) $newAction;
         }
+
+        return $this;
+    }
+
+    /**
+     * Add a button.
+     * Wrapper for a potential action by just providing $text and $url params.
+     *
+     * @param string $text - label of the button
+     * @param string $url - url to forward to
+     * @param array $params - optional params (needed for more complex types  and for section)
+     * For more information check out: https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#openuri-action
+     *
+     * @return MicrosoftTeamsMessage $this
+     */
+    public function button(string $text, string $url = '', array $params = []): self
+    {
+
+        // fill targets that is needed for a button
+        $newButton = [
+            'targets' => [
+                (object) [
+                    'os'=> 'default',
+                    'uri' => $url,
+                ],
+            ]
+        ];
+
+        // fill additional params (if any)
+        if (! empty($params)) {
+            $newButton = array_merge($newButton, $params);
+        }
+
+        $this->action($text, 'OpenUri', $newButton);
 
         return $this;
     }

--- a/tests/MicrosoftTeamsMessageTest.php
+++ b/tests/MicrosoftTeamsMessageTest.php
@@ -125,6 +125,19 @@ class MicrosoftTeamsMessageTest extends TestCase
     }
 
     /** @test */
+    public function an_action_with_options_can_be_added_to_the_messsage(): void
+    {
+        $message = new MicrosoftTeamsMessage();
+        $message->action('Laravel', 'HttpPOST', ['body' => 'test body']);
+        $expectedButton = (object) [
+             '@type' => 'HttpPOST',
+             'name' => 'Laravel',
+             'body' => 'test body',
+         ];
+        $this->assertEquals($expectedButton, $message->getPayloadValue('potentialAction')[0]);
+    }
+
+    /** @test */
     public function a_standard_button_can_be_added_to_the_messsage(): void
     {
         $message = new MicrosoftTeamsMessage();
@@ -146,12 +159,42 @@ class MicrosoftTeamsMessageTest extends TestCase
     public function a_button_with_additional_options_can_be_added_to_the_messsage(): void
     {
         $message = new MicrosoftTeamsMessage();
-        $message->button('Laravel', 'https://laravel.com', 'HttpPOST', ['body' => 'test body']);
+        $message->button('Laravel', 'https://laravel.com', ['body' => 'test body']);
         $expectedButton = (object) [
-            '@type' => 'HttpPOST',
+            '@type' => 'OpenUri',
             'name' => 'Laravel',
+            'targets' => [
+                (object) [
+                    'os'=> 'default',
+                    'uri' => 'https://laravel.com',
+                ],
+            ],
             'body' => 'test body',
         ];
+        $this->assertEquals($expectedButton, $message->getPayloadValue('potentialAction')[0]);
+    }
+
+    /** @test */
+    public function a_button_with_custom_targets_are_overwriting_the_standard_targets_of_the_messsage(): void
+    {
+        $message = new MicrosoftTeamsMessage();
+        $customTargets = ['targets' => [
+            (object) [
+                'os'=> 'android',
+                'uri' => 'https://android.laravel.com',
+            ],
+            (object) [
+                'os'=> 'iOS',
+                'uri' => 'https://ios.laravel.com',
+            ],
+            ]
+        ];
+        $message->button('Laravel', 'https://laravel.com', $customTargets);
+        $expectedButton = (object) [
+             '@type' => 'OpenUri',
+             'name' => 'Laravel',
+             'targets' => $customTargets['targets']
+         ];
         $this->assertEquals($expectedButton, $message->getPayloadValue('potentialAction')[0]);
     }
 
@@ -204,10 +247,23 @@ class MicrosoftTeamsMessageTest extends TestCase
     }
 
     /** @test */
+    public function an_action_can_be_added_to_a_section(): void
+    {
+        $message = new MicrosoftTeamsMessage();
+        $message->action('Laravel', 'HttpPOST', ['section' => 1]);
+        $expectedButton = (object) [
+            '@type' => 'HttpPOST',
+            'name' => 'Laravel',
+        ];
+        $this->assertEquals($expectedButton, $message->getPayloadValue('sections')[1]['potentialAction'][0]);
+        $this->assertEmpty($message->getPayloadValue('potentialAction'));
+    }
+
+    /** @test */
     public function a_standard_button_can_be_added_to_a_section(): void
     {
         $message = new MicrosoftTeamsMessage();
-        $message->button('Laravel', 'https://laravel.com', 'OpenUri', ['section' => 1]);
+        $message->button('Laravel', 'https://laravel.com', ['section' => 1]);
         $expectedButton = (object) [
             '@type' => 'OpenUri',
             'name' => 'Laravel',
@@ -415,7 +471,7 @@ class MicrosoftTeamsMessageTest extends TestCase
             ->heroImage('https://messagecardplayground.azurewebsites.net/assets/TINYPulseQuestionIcon.png', 'TooltipHero', 'image_section')
             ->image('https://messagecardplayground.azurewebsites.net/assets/FlowLogo.png', 'Tooltip', 'image_section')
             ->image('https://messagecardplayground.azurewebsites.net/assets/FlowLogo2.png', 'Tooltip2', 'image_section')
-            ->button('Laravel', 'https://laravel.com', 'OpenUri', ['section' => 'image_section']);
+            ->button('Laravel', 'https://laravel.com', ['section' => 'image_section']);
         $expected = [
             '@type' => 'MessageCard',
             '@context' => 'https://schema.org/extensions',

--- a/tests/MicrosoftTeamsMessageTest.php
+++ b/tests/MicrosoftTeamsMessageTest.php
@@ -130,10 +130,10 @@ class MicrosoftTeamsMessageTest extends TestCase
         $message = new MicrosoftTeamsMessage();
         $message->action('Laravel', 'HttpPOST', ['body' => 'test body']);
         $expectedButton = (object) [
-             '@type' => 'HttpPOST',
-             'name' => 'Laravel',
-             'body' => 'test body',
-         ];
+            '@type' => 'HttpPOST',
+            'name' => 'Laravel',
+            'body' => 'test body',
+        ];
         $this->assertEquals($expectedButton, $message->getPayloadValue('potentialAction')[0]);
     }
 
@@ -187,14 +187,14 @@ class MicrosoftTeamsMessageTest extends TestCase
                 'os'=> 'iOS',
                 'uri' => 'https://ios.laravel.com',
             ],
-            ]
+        ],
         ];
         $message->button('Laravel', 'https://laravel.com', $customTargets);
         $expectedButton = (object) [
-             '@type' => 'OpenUri',
-             'name' => 'Laravel',
-             'targets' => $customTargets['targets']
-         ];
+            '@type' => 'OpenUri',
+            'name' => 'Laravel',
+            'targets' => $customTargets['targets'],
+        ];
         $this->assertEquals($expectedButton, $message->getPayloadValue('potentialAction')[0]);
     }
 


### PR DESCRIPTION
- change method button() to action() since this fits better to the documentation as [potential action](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions)
- add button() method as a wrapper for straight forward use